### PR TITLE
Remove -tune, join ffmpeg args for easier debug

### DIFF
--- a/ufv.js
+++ b/ufv.js
@@ -301,7 +301,6 @@ UFV.prototype.handleStreamRequest = function(request) {
           '-vcodec', 'copy',
           '-an',
           '-f', 'rawvideo',
-          '-tune', 'zerolatency',
           '-bufsize', vbitrate +'k',
           '-payload_type', '99',
           '-ssrc', videoSsrc,
@@ -330,7 +329,7 @@ UFV.prototype.handleStreamRequest = function(request) {
             `srtp://${targetAddress}:${targetAudioPort}?rtcpport=${targetAudioPort}&localrtcpport=${targetAudioPort}&pkt_size=1378`,
           );
         }
-        console.log(ffmpegCommand);
+        console.log(ffmpegCommand.join(' '));
         let ffmpeg = spawn('ffmpeg', ffmpegCommand, {env: process.env});
         this.ongoingSessions[sessionIdentifier] = ffmpeg;
       }


### PR DESCRIPTION
`-tune zerolatency` and `-vcodec copy` don't play nice on my ffmpeg version git-2019-07-18-ab4795a (see https://github.com/gozoinks/homebridge-camera-ffmpeg-ufv/issues/34). After removing the tuning parameter streaming works. Thanks for the initial work - the resource utilization is so much better now, and audio kind of works...